### PR TITLE
Fix fatal syntax error with colon

### DIFF
--- a/javalink/ref.py
+++ b/javalink/ref.py
@@ -96,7 +96,7 @@ def purge_imports(app, env, docname):
 def merge_imports(env, docnames, other):
     if not hasattr(other, 'javalink_imports'):
         return
-    if not hasattr(env, 'javalink_imports')
+    if not hasattr(env, 'javalink_imports'):
         env.javalink_imports = {}
 
     docs_with_imports = (d for d in docnames if d in other.javalink_imports)


### PR DESCRIPTION
Fix for:

```
C:\Users\david.f>python -c "import javalink"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "C:\Python27\lib\site-packages\javalink\__init__.py", line 7, in <module>

    from . import ref
  File "C:\Python27\lib\site-packages\javalink\ref.py", line 99
    if not hasattr(env, 'javalink_imports')
                                          ^
SyntaxError: invalid syntax
```
