### PR TITLE
This commit handles method ambiguity in classes

### DIFF
--- a/javalink/model.py
+++ b/javalink/model.py
@@ -59,8 +59,7 @@ class LinkableClass(object):
         match = re.match(r'^(.+?)(?:\((.*)\))?$', member)
         if match:
             name, args = match.group(1, 2)
-            method = next((m for m in self.methods if name == m.name), None)
-            if method:
+            for method in [m for m in self.methods if name == m.name]:
                 if args is None:
                     return method
 

--- a/javalink/ref.py
+++ b/javalink/ref.py
@@ -122,7 +122,6 @@ class JavarefRole(EnvAccessor):
         if clazz:
             where = clazz.full_name
             if what:
-                # TODO handle member ambiguity
                 member = clazz.get_member(what)
                 if not member:
                     raise JavarefError('unknown member: {}'.format(reftext))


### PR DESCRIPTION
The problem we were facing was that overloaded methods were not
correctly resolved. Only the first occurrence of the method was
inspected.
