### PR TITLE
Cache empty class search

### DIFF
--- a/javalink/loader.py
+++ b/javalink/loader.py
@@ -61,10 +61,9 @@ class ClassLoader(object):
             return self.packages[package][class_name]
         except KeyError:
             clazz = self.find(name)
-            if clazz:
-                if clazz.package != package or clazz.name != class_name:
-                    msg = "Wanted class '{}', but '{}' was loaded"
-                    raise ValueError(msg.format(name, clazz))
+            if clazz and (clazz.package != package or clazz.name != class_name):
+                msg = "Wanted class '{}', but '{}' was loaded"
+                raise ValueError(msg.format(name, clazz))
 
             classes = self.packages.setdefault(package, {})
             classes[class_name] = clazz

--- a/javalink/loader.py
+++ b/javalink/loader.py
@@ -66,9 +66,8 @@ class ClassLoader(object):
                     msg = "Wanted class '{}', but '{}' was loaded"
                     raise ValueError(msg.format(name, clazz))
 
-                classes = self.packages.setdefault(package, {})
-                classes[class_name] = clazz
-
+            classes = self.packages.setdefault(package, {})
+            classes[class_name] = clazz
             return clazz
 
     def find(self, name):


### PR DESCRIPTION
Cache empty class results when searching a package. This prevents a class from searching the same packages over and over again if it appears multiple times in the document.

My local docs project build time went from ~4m30s to ~2m45s.
