### PR TITLE
Fix javalink_packages error

### DIFF
--- a/javalink/__init__.py
+++ b/javalink/__init__.py
@@ -19,15 +19,18 @@ def setup(app):
     app.add_directive('javaimport', ref.JavarefImportDirective)
     app.add_role('javaref', ref.JavarefRole(app))
 
-    # initialize_package_list must happen after validate_env
-    app.connect('builder-inited', validate_env)
-    app.connect('builder-inited', ref.initialize_package_list)
+    app.connect('builder-inited', initialize_package_list)
 
     app.connect('env-purge-doc', ref.purge_imports)
     app.connect('env-merge-info', ref.merge_imports)
 
     app.connect('build-finished', ref.cleanup)
 
+
+def initialize_package_list(app):
+    # initialize_package_list must happen after validate_env
+    validate_env(app)
+    ref.initialize_package_list(app)
 
 def validate_env(app):
     """Purge expired values from the environment.


### PR DESCRIPTION
When trying out your latest plugin with sphinx 1.3.3, I kept getting this error:

```
Exception occurred:
  File "/Users/ryanlepinski/git/extdocs/_extensions/javalink/ref.py", line 220, in _find_url_root
    return self.env.javalink_packages.get(package.name, None)
AttributeError: BuildEnvironment instance has no attribute 'javalink_packages'
The full traceback has been saved in /var/folders/s9/_8x3w_4540n__1hrzx11syhh0000gn/T/sphinx-err-h5PjhJ.log, if you want to report the issue to the developers.
```

It seems that validate_env is occurring after initialize_package_list.

full traceback: https://gist.github.com/rlepinski/0751f405ef7c5ff892b3
